### PR TITLE
Update to Node.js 20.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-          token: ${{ secrets.BECKWITH_ROBOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/action.yml
+++ b/action.yml
@@ -59,5 +59,5 @@ outputs:
   results:
     description: 'The full results of the scan.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
The default version of Node.js supported by GitHub Actions will change to 20.x.

Reference: <https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/>

To change the Node.js version specified in action.yml to `'node20'`.

<https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/>

To change the Node.js version specified in action.yml to `'node20'`.