### PR TITLE
fix: surface underlying network errors

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -101,7 +101,7 @@ function getDisplayStatus(link) {
  * @param {object} link The link result object
  * @returns {string} A human-readable failure reason
  */
-function getFailureReason(link) {
+export function getFailureReason(link) {
   // If there are no failure details, return generic message
   if (!link.failureDetails || link.failureDetails.length === 0) {
     return link.status ? 'HTTP Error' : 'Request failed';
@@ -112,19 +112,62 @@ function getFailureReason(link) {
     return 'Fragment not found';
   }
 
-  // Check for other error messages in failure details
+  // Prefer the most specific message in the error cause chain. Undici wraps
+  // network errors such as ENOTFOUND and ECONNREFUSED in `TypeError: fetch
+  // failed`, so reporting only the outer message hides the actionable detail.
   for (const detail of link.failureDetails) {
-    if (detail instanceof Error) {
-      const message = detail.message || '';
-      // Return the error message if it's informative
-      if (message && message.length < 100) {
-        return message;
+    const messages = [];
+    const seen = new Set();
+    let error = detail;
+
+    while (error && typeof error === 'object' && !seen.has(error)) {
+      seen.add(error);
+      if (typeof error.message === 'string' && error.message) {
+        messages.push(error.message);
       }
+      error = error.cause;
+    }
+
+    if (messages.length > 0) {
+      return messages.at(-1);
     }
   }
 
   // Default to HTTP error for other cases
   return link.status ? `HTTP ${link.status}` : 'Request failed';
+}
+
+/**
+ * Serialize failure details, including non-enumerable Error properties.
+ * @param {unknown} failureDetails Linkinator failure details
+ * @returns {string} JSON suitable for DEBUG logging
+ */
+export function stringifyFailureDetails(failureDetails) {
+  const seen = new WeakSet();
+
+  return JSON.stringify(
+    failureDetails,
+    (_key, value) => {
+      if (value && typeof value === 'object') {
+        if (seen.has(value)) {
+          return '[Circular]';
+        }
+        seen.add(value);
+
+        if (value instanceof Error) {
+          return {
+            name: value.name,
+            message: value.message,
+            stack: value.stack,
+            cause: value.cause,
+            ...value,
+          };
+        }
+      }
+      return value;
+    },
+    2,
+  );
 }
 
 export async function generateJobSummary(result, logger) {
@@ -289,7 +332,7 @@ export async function main() {
           const reason = getFailureReason(link);
           const displayStatus = getDisplayStatus(link);
           failureOutput += `\n   [${displayStatus}] ${link.url} - ${reason}`;
-          logger.debug(JSON.stringify(link.failureDetails, null, 2));
+          logger.debug(stringifyFailureDetails(link.failureDetails));
         }
       }
       core.setFailed(failureOutput);

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,13 @@ vi.mock('@actions/core', () => ({
 }));
 
 import * as core from '@actions/core';
-import { getFullConfig, main, generateJobSummary } from '../src/action.js';
+import {
+  generateJobSummary,
+  getFailureReason,
+  getFullConfig,
+  main,
+  stringifyFailureDetails,
+} from '../src/action.js';
 
 let mockAgent;
 
@@ -293,6 +299,32 @@ describe('linkinator action', () => {
       .some((call) => /status|headers/.test(call[0]));
     assert.ok(hasFailureDetails);
     scope.done();
+  });
+
+  it('should surface the underlying cause of fetch failures', () => {
+    const cause = new Error(
+      'getaddrinfo ENOTFOUND this-domain-does-not-exist.invalid',
+    );
+    const failure = new TypeError('fetch failed', { cause });
+
+    assert.strictEqual(
+      getFailureReason({ status: 0, failureDetails: [failure] }),
+      'getaddrinfo ENOTFOUND this-domain-does-not-exist.invalid',
+    );
+  });
+
+  it('should include Error messages and causes in DEBUG details', () => {
+    const cause = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1'), {
+      code: 'ECONNREFUSED',
+    });
+    const failure = new TypeError('fetch failed', { cause });
+
+    const details = stringifyFailureDetails([failure]);
+
+    assert.match(details, /"message": "fetch failed"/);
+    assert.match(details, /"message": "connect ECONNREFUSED 127\.0\.0\.1"/);
+    assert.match(details, /"code": "ECONNREFUSED"/);
+    assert.notStrictEqual(details, '[\n  {}\n]');
   });
 
   it('should respect local config with overrides', async () => {


### PR DESCRIPTION
Fixes #236.

## What changed

- Walk nested `Error.cause` chains and show the most specific failure message in console output, job summaries, and the action failure message.
- Serialize non-enumerable `Error` fields and nested causes for DEBUG logs instead of producing `{}`.
- Add regression coverage for DNS and connection failures.

## Why

Undici wraps network errors in `TypeError: fetch failed`. The useful error, such as `ENOTFOUND` or `ECONNREFUSED`, is stored in `error.cause`. The action previously displayed only the wrapper message, while `JSON.stringify(Error)` hid all useful DEBUG fields.

## Impact

Failures now identify their underlying network cause without requiring workflow changes. HTTP and fragment failure formatting remains unchanged.

## Validation

- `npm test` — 37 tests passed
- `npm run build`
- `npm run lint` — passed with the existing Biome schema-version informational notice
