### PR TITLE
docs: overhaul README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,84 +1,277 @@
-# linkinator-action
+# Linkinator Action
 
-> A happy little GitHub Action that checks your README.md and other markdown for broken links.  Uses [linkinator](https://github.com/JustinBeckwith/linkinator) under the hood.
+> Find broken links in Markdown, HTML, and websites—directly in GitHub Actions.
 
-![linkinator-action](https://raw.githubusercontent.com/JustinBeckwith/linkinator-action/main/site/linkinator-action.webp)
+[Linkinator Action](https://github.com/JustinBeckwith/linkinator-action) is the GitHub Actions wrapper for [Linkinator](https://github.com/JustinBeckwith/linkinator). It checks local documentation and remote URLs, annotates failures in the workflow log, and writes a readable job summary.
 
-## Example usage
+![Linkinator Action](https://raw.githubusercontent.com/JustinBeckwith/linkinator-action/main/site/linkinator-action.webp)
 
-With no arguments, this will scan your `README.md` in the root of the GitHub repository:
+## Quick start
+
+Add `.github/workflows/links.yml` to your repository:
 
 ```yaml
+name: Check links
+
 on:
-  push:
-    branches:
-      - main
   pull_request:
-name: ci
+  push:
+    branches: [main]
+
 jobs:
   linkinator:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: JustinBeckwith/linkinator-action@v2
 ```
 
-Or you can pass many of the same parameters [linkinator](https://github.com/JustinBeckwith/linkinator) provides!
+That is it. By default, the action checks Markdown files matching `*.md` in the repository root and fails the job when it finds a broken link.
+
+To scan every Markdown file in the repository:
 
 ```yaml
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-name: ci
-jobs:
-  linkinator:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: JustinBeckwith/linkinator-action@v2
-        with:
-          paths: test/fixtures/test.md
-          concurrency: 1
-          markdown: true
-          linksToSkip: "http://fake.local, http://fake.local/fake"
+- uses: JustinBeckwith/linkinator-action@v2
+  with:
+    paths: '**/*.md'
 ```
+
+## What you get
+
+- Broken-link annotations in the workflow log
+- A GitHub Actions job summary grouped by source file
+- Support for local files, remote pages, redirects, fragments, and CSS URLs
+- Configurable retries, timeouts, status-code policies, and skip patterns
+- A machine-readable `results` output for later workflow steps
+
+## Common recipes
+
+### Check anchors and fragments
+
+Fragment checking is opt-in because it requires downloading and parsing page content:
+
+```yaml
+- uses: JustinBeckwith/linkinator-action@v2
+  with:
+    paths: '**/*.md'
+    checkFragments: true
+```
+
+### Skip unreliable or private URLs
+
+`linksToSkip` accepts comma- or whitespace-separated regular expressions. Skip rules are matched against the complete URL, including fragments.
+
+```yaml
+- uses: JustinBeckwith/linkinator-action@v2
+  with:
+    paths: '**/*.md'
+    linksToSkip: >-
+      ^https://example\.com/private
+      ^https://(?:www\.)?ghostbrowser\.com(?:/|$)
+      .*#L[0-9]+(?:-L[0-9]+)?$
+```
+
+`skip` is supported as an alias for `linksToSkip`.
+
+### Retry transient failures
+
+```yaml
+- uses: JustinBeckwith/linkinator-action@v2
+  with:
+    paths: '**/*.md'
+    timeout: 15000
+    retry: true
+    retryErrors: true
+    retryErrorsCount: 3
+    retryErrorsJitter: 2000
+```
+
+`retry` handles HTTP 429 responses with a `retry-after` header. `retryErrors` handles network errors and 5xx responses.
+
+### Customize status-code handling
+
+Map an exact status or a status family to `ok`, `warn`, `skip`, or `error`:
+
+```yaml
+- uses: JustinBeckwith/linkinator-action@v2
+  with:
+    statusCodes: '{"403":"warn","429":"skip","5xx":"warn"}'
+```
+
+### Enforce HTTPS and flag redirects
+
+```yaml
+- uses: JustinBeckwith/linkinator-action@v2
+  with:
+    requireHttps: error
+    redirects: warn
+```
+
+`requireHttps` accepts `off`, `warn`, or `error`. The boolean values `true` and `false` are aliases for `error` and `off`. `redirects` accepts `allow`, `warn`, or `error`.
+
+### Check a website recursively
+
+```yaml
+- uses: JustinBeckwith/linkinator-action@v2
+  with:
+    paths: https://example.com
+    recurse: true
+    concurrency: 20
+```
+
+Recursive scans follow links on the same root domain. Use a reasonable concurrency value when scanning a site you do not control.
+
+### Check CSS URLs
+
+```yaml
+- uses: JustinBeckwith/linkinator-action@v2
+  with:
+    paths: public
+    checkCss: true
+```
+
+This extracts URLs from CSS files, `<style>` blocks, and inline styles.
+
+### Support clean URLs and directory links
+
+```yaml
+- uses: JustinBeckwith/linkinator-action@v2
+  with:
+    paths: docs
+    cleanUrls: true
+    directoryListing: true
+```
+
+`cleanUrls` lets a link such as `/about` resolve to `about.html`. `directoryListing` lets local links to directories resolve through an automatically generated directory index and defaults to `true`.
+
+### Rewrite URLs in pull requests
+
+The action automatically rewrites matching GitHub `blob` and `tree` links from the base branch to the pull request branch. You can also define one custom rewrite:
+
+```yaml
+- uses: JustinBeckwith/linkinator-action@v2
+  with:
+    urlRewriteSearch: '^https://docs\.example\.com/'
+    urlRewriteReplace: 'https://preview.example.com/'
+```
+
+Both rewrite inputs must be provided together.
+
+## Configuration file
+
+For a larger configuration, add `linkinator.config.json` to the repository:
+
+```json
+{
+  "recurse": false,
+  "concurrency": 20,
+  "skip": [
+    "^https://example\\.com/private",
+    "^mailto:"
+  ],
+  "statusCodes": {
+    "403": "warn",
+    "429": "skip",
+    "5xx": "warn"
+  }
+}
+```
+
+Then reference it from the workflow:
+
+```yaml
+- uses: JustinBeckwith/linkinator-action@v2
+  with:
+    paths: '**/*.md'
+    config: linkinator.config.json
+```
+
+Values supplied directly to the action take precedence over the configuration file. See the [Linkinator API options](https://github.com/JustinBeckwith/linkinator#api-usage) for the underlying configuration format.
 
 ## Inputs
 
-- `paths` - Paths to scan for 404s. Defaults to `*.md`.
-- `config` - Path to a config file to use. Looks for `linkinator.config.json` by default. Options defined via the GitHub Action config will take precedence.
-- `concurrency` - The number of connections to make simultaneously. Defaults to `100`.
-- `recurse` - Recursively follow links on the same root domain.  Defaults to `false`.
-- `linksToSkip` - List of urls in regexy form to not include in the check. (`skip` is also accepted)
-- `timeout` - Request timeout in ms.  Defaults to 0 (no timeout).
-- `markdown` - Automatically parse and scan markdown if scanning from a location on disk. Defaults to `true`.
-- `serverRoot` - When scanning a local directory, customize the location on disk where the server is started.  Defaults to the root of your GitHub repository.
-- `directoryListing` - Include an automatic directory index file when linking to a directory. Defaults to `true`.
-- `retry` - Automatically retry requests that return HTTP 429 responses and include a `retry-after` header. Defaults to `false`.
-- `retryErrors` - Automatically retry requests that return 5xx or network error responses. Defaults to `false`.
-- `retryErrorsCount` - The number of times to retry requests that return 5xx or network error responses. Defaults to `3`.
-- `retryErrorsJitter` - The maximum jitter in milliseconds to apply to retry delays. Defaults to `2000`.
-- `userAgent` - Custom User-Agent header to use for requests.
-- `allowInsecureCerts` - Allow checking links with insecure certificates. Useful for local development with self-signed certificates. Defaults to `false`.
-- `requireHttps` - Require links to use HTTPS. Accepts `off`, `warn`, or `error`; `true` is an alias for `error` and `false` is an alias for `off`. Defaults to `false`.
-- `cleanUrls` - Enable support for clean URLs (extensionless paths). Allows validation of URLs without file extensions, useful for modern static hosting. Defaults to `false`.
-- `checkCss` - Enable parsing and extraction of URLs from CSS files, style blocks, and inline styles. Defaults to `false`.
-- `checkFragments` - Enable validation of fragment identifiers (anchor links) on HTML pages. Defaults to `false`.
-- `statusCodes` - JSON object mapping HTTP status codes to actions (`ok`, `warn`, `skip`, `error`). Supports patterns like `4xx` or `5xx`. Example: `{"404": "error", "5xx": "warn", "301": "ok"}`.
-- `redirects` - How to handle HTTP redirects. Options: `allow` (default), `warn`, or `error`.
-- `urlRewriteSearch` - Pattern to search for in urls.  Must be used with `urlRewriteReplace`.
-- `urlRewriteReplace` - Expression used to replace search content.  Must be used with `urlRewriteSearch`.
-- `verbosity` - Override the default verbosity for this command. Available options are "DEBUG", "INFO", "WARNING", "ERROR", and "NONE".  Defaults to "WARNING".
+| Input | Default | Description |
+| --- | --- | --- |
+| `paths` | `*.md` | Comma- or whitespace-separated paths, globs, directories, or URLs to scan. |
+| `config` | `linkinator.config.json` when present | Path to a Linkinator configuration file. |
+| `concurrency` | `100` | Maximum number of concurrent requests. |
+| `recurse` | `false` | Follow same-domain links recursively. |
+| `linksToSkip` | — | Comma- or whitespace-separated URL regular expressions to skip. |
+| `skip` | — | Alias for `linksToSkip`. |
+| `timeout` | `0` | Request timeout in milliseconds; `0` disables the action-level timeout. |
+| `markdown` | `true` | Parse Markdown when scanning local files. |
+| `serverRoot` | repository root | Root from which local files are served. |
+| `directoryListing` | `true` | Generate directory listings for local directory links. |
+| `retry` | `false` | Retry 429 responses that include `retry-after`. |
+| `retryErrors` | `false` | Retry network errors and 5xx responses. |
+| `retryErrorsCount` | `3` | Maximum retries for network errors and 5xx responses. |
+| `retryErrorsJitter` | `2000` | Maximum retry-delay jitter in milliseconds. |
+| `userAgent` | Linkinator default | Custom HTTP User-Agent header. |
+| `verbosity` | `WARNING` | One of `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `NONE`. |
+| `urlRewriteSearch` | — | Regular expression used for a custom URL rewrite. |
+| `urlRewriteReplace` | — | Replacement used with `urlRewriteSearch`. |
+| `allowInsecureCerts` | `false` | Allow invalid or self-signed TLS certificates. |
+| `requireHttps` | `false` (`off`) | HTTPS policy: `off`, `warn`, or `error`. |
+| `cleanUrls` | `false` | Resolve extensionless local links to `.html` files. |
+| `checkCss` | `false` | Extract and check URLs found in CSS. |
+| `checkFragments` | `false` | Validate fragment identifiers and anchors. |
+| `statusCodes` | Linkinator defaults | JSON object mapping statuses or families to `ok`, `warn`, `skip`, or `error`. |
+| `redirects` | `allow` | Redirect policy: `allow`, `warn`, or `error`. |
+
+Boolean inputs should be written as `true` or `false`. See [`action.yml`](action.yml) for the canonical action metadata.
 
 ## Outputs
 
-- `results` - An object with the results of the run.
+The action exposes the full Linkinator result as `results`:
 
-## Debugging
+```yaml
+- id: links
+  uses: JustinBeckwith/linkinator-action@v2
 
-To view skipped links, failure details, and more debugging information [enable step debug logging](https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/enabling-debug-logging#enabling-step-debug-logging).
+- name: Inspect results
+  if: always()
+  env:
+    LINKINATOR_RESULTS: ${{ steps.links.outputs.results }}
+  run: echo "$LINKINATOR_RESULTS"
+```
+
+The result includes the overall pass/fail state and each checked link's URL, status, state, parent, and failure details.
+
+## Troubleshooting
+
+### A valid URL reports a network failure
+
+The action reports the underlying transport cause when available, such as `ENOTFOUND`, `ECONNREFUSED`, or a timeout. These failures can be specific to automated clients or GitHub-hosted runners.
+
+1. Add a reasonable `timeout` and enable `retryErrors` for transient services.
+2. Set `verbosity: DEBUG` to include complete error and cause details.
+3. Add persistently bot-protected or unreliable domains to `linksToSkip`.
+
+### Relative directory links return 404
+
+Keep `directoryListing: true` when local documentation links to directories without an index file. If links are resolved from the wrong location, set `serverRoot` to the directory that represents the site's root.
+
+### A skip pattern does not match
+
+Skip values are regular expressions, not shell globs. Quote patterns in YAML, escape literal dots (`example\.com`), and remember that inputs are split on commas and whitespace. Use a configuration file when a pattern itself must contain either delimiter.
+
+### I need more logging
+
+Set `verbosity: DEBUG`. To include GitHub runner diagnostics as well, [enable debug logging in GitHub Actions](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/troubleshooting-workflows/enabling-debug-logging).
+
+## Versioning and security
+
+Use the moving major tag for automatic compatible updates:
+
+```yaml
+- uses: JustinBeckwith/linkinator-action@v2
+```
+
+For a fully immutable workflow, pin the action to a commit SHA and let a dependency updater manage it. The action runs on the Node.js runtime bundled by GitHub Actions; consumers do not need to install Node.js themselves.
+
+## Contributing
+
+Issues and pull requests are welcome. For changes to the underlying checker, visit the [Linkinator repository](https://github.com/JustinBeckwith/linkinator).
 
 ## License
 


### PR DESCRIPTION
## Summary

- replace the minimal README with a copy/paste quick start and clearer product overview
- add practical recipes for fragments, skips, retries, status policies, HTTPS, redirects, recursive scans, CSS, clean URLs, directory links, and rewrites
- document configuration files, every action input, workflow outputs, version pinning, and common troubleshooting paths
- update examples to current action versions and remove stale or nonexistent documentation links

## Why

The existing README listed the inputs but did not help users choose them or diagnose common failures. The new structure gets a first workflow running immediately, then progressively introduces advanced configuration with tested examples.

## Validation

- `npm test` — 37 tests passed
- `npm run build`
- `npm run lint` — passed with the existing Biome schema-version informational notice
- `linkinator README.md --check-fragments` — 7 links passed
