### PR TITLE
ci: restore release boundaries

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -43,22 +43,45 @@ jobs:
           tag='${{ steps.release.outputs.tag_name }}'
           major='v${{ steps.release.outputs.major }}'
           minor='v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}'
+          release_sha='${{ steps.release.outputs.sha }}'
 
-          if git rev-parse "refs/tags/$tag" >/dev/null 2>&1; then
-            echo "Refusing to replace existing release tag $tag" >&2
+          # Release Please creates the tag before this step so that draft
+          # releases still establish a boundary for the next release PR. Only
+          # move that tag when it points at the release commit from this run.
+          tag_sha="$(git rev-list -n 1 "$tag")"
+          if [[ "$tag_sha" != "$release_sha" ]]; then
+            echo "Refusing to replace $tag at unexpected commit $tag_sha" >&2
             exit 1
           fi
 
+          # last-release-sha repairs the boundary for the first release after
+          # this workflow change. Remove it in that packaged release commit so
+          # subsequent runs return to normal tag discovery.
+          node --input-type=module -e '
+            import fs from "node:fs";
+            const path = "release-please-config.json";
+            const config = JSON.parse(fs.readFileSync(path, "utf8"));
+            if (config["last-release-sha"]) {
+              delete config["last-release-sha"];
+              fs.writeFileSync(path, JSON.stringify(config, null, 2) + "\n");
+            }
+          '
+
           git add --force dist/index.cjs dist/index.cjs.map
+          git add release-please-config.json
           git commit -m "chore: package $tag"
-          git tag --annotate "$tag" --message "Release $tag"
+          git tag --force --annotate "$tag" --message "Release $tag"
           git tag --force --annotate "$major" --message "Release $major"
           git tag --force --annotate "$minor" --message "Release $minor"
 
-          git push --atomic --force origin \
-            "refs/tags/$tag" \
-            "refs/tags/$major" \
-            "refs/tags/$minor"
+          # Keep the packaged commit in main's history so Release Please can
+          # find the final immutable tag on later runs. The branch update is a
+          # normal fast-forward; only the release tags are force-updated.
+          git push --atomic origin \
+            HEAD:refs/heads/main \
+            "+refs/tags/$tag" \
+            "+refs/tags/$major" \
+            "+refs/tags/$minor"
       - name: Publish the immutable release
         if: ${{ steps.release.outputs.release_created }}
         env:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,6 @@
 {
+  "force-tag-creation": true,
+  "last-release-sha": "aed8a13fc74597852f21eddd477e369c1c1ae593",
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

- force Release Please to create tags for draft releases before calculating the next release
- temporarily anchor release discovery at the real v2.4.3 release commit
- keep generated bundle commits in `main` so final immutable tags remain reachable from the release branch
- validate the version tag before moving it to the packaged commit
- update `main` and all action tags atomically, while requiring the branch update to remain a fast-forward
- automatically remove the one-time `last-release-sha` recovery override in the next packaged release commit

## Root cause

Draft releases delayed tag creation, so Release Please calculated a follow-up PR before it could see the new release boundary. The custom packaging step then placed the final version tag on an unbranched child commit, which remained unreachable from `main`. Every later run therefore reprocessed old history, rediscovered the already-released Linkinator 7 breaking commit, and proposed 3.0.0.

## Expected recovery

After this merges, Release Please should replace the bogus 3.0.0 proposal with a 2.4.4 release containing only changes after v2.4.3. When that release merges, its packaging commit removes the temporary boundary override. Later releases use normal reachable-tag discovery.

## Safety

- the workflow refuses to replace a version tag unless it points to the release SHA from the current run
- the branch update must be a normal fast-forward
- branch and tag updates use one atomic push, preventing partial publication

## Validation

- `actionlint .github/workflows/release-please.yml`
- `npm test` — 37 tests passed
- `npm run lint` — passed with the existing Biome schema-version informational notice
- `release-please-config.json` parsed as valid JSON

Fixes the release loop demonstrated by #278 and #281.
