### PR TITLE
fix: package action bundle before release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,11 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
+      - name: Verify the release bundle is reproducible
+        if: "${{ startsWith(github.head_ref, 'release-please--branches--') || contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}"
+        run: |
+          npm run build
+          git diff --exit-code -- dist/index.cjs dist/index.cjs.map
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,109 +15,56 @@ jobs:
         id: release
         with:
           token: ${{ secrets.BECKWITH_ROBOT_TOKEN }}
-      - name: Check out the released source
-        if: ${{ steps.release.outputs.release_created }}
+      - name: Check out the release pull request
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ steps.release.outputs.sha }}
-          fetch-depth: 0
-          token: ${{ secrets.BECKWITH_ROBOT_TOKEN }}
-      - name: Check out the packaged release
-        if: "${{ !steps.release.outputs.release_created && startsWith(github.event.head_commit.message, 'chore: package v') }}"
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
+          ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
           fetch-depth: 0
           token: ${{ secrets.BECKWITH_ROBOT_TOKEN }}
       - name: Set up Node.js
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: npm
       - name: Build the release bundle
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
         run: |
           npm ci
-          npm test
           npm run build
-      - name: Create the release packaging pull request
-        if: ${{ steps.release.outputs.release_created }}
-        env:
-          GH_TOKEN: ${{ secrets.BECKWITH_ROBOT_TOKEN }}
+      - name: Commit the release bundle
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-
-          tag='${{ steps.release.outputs.tag_name }}'
-          release_sha='${{ steps.release.outputs.sha }}'
-          branch="release/package-$tag"
-
-          # Release Please creates the tag before this step so that draft
-          # releases still establish a boundary for the next release PR. Only
-          # package a tag when it points at the release commit from this run.
-          tag_sha="$(git rev-list -n 1 "$tag")"
-          if [[ "$tag_sha" != "$release_sha" ]]; then
-            echo "Refusing to package $tag at unexpected commit $tag_sha" >&2
-            exit 1
-          fi
-
-          # last-release-sha repairs the boundary for the first release after
-          # this workflow change. Remove it in that packaged release commit so
-          # subsequent runs return to normal tag discovery.
-          node --input-type=module -e '
-            import fs from "node:fs";
-            const path = "release-please-config.json";
-            const config = JSON.parse(fs.readFileSync(path, "utf8"));
-            if (config["last-release-sha"]) {
-              delete config["last-release-sha"];
-              fs.writeFileSync(path, JSON.stringify(config, null, 2) + "\n");
-            }
-          '
 
           git add --force dist/index.cjs dist/index.cjs.map
-          git add release-please-config.json
-          git commit -m "chore: package $tag"
-
-          remote_sha="$(git ls-remote --heads origin "$branch" | cut -f1)"
-          git push \
-            --force-with-lease="refs/heads/$branch:$remote_sha" \
-            origin "HEAD:refs/heads/$branch"
-
-          pr_url="$(gh pr list --state open --head "$branch" --json url --jq '.[0].url')"
-          if [[ -z "$pr_url" ]]; then
-            pr_url="$(gh pr create \
-              --base main \
-              --head "$branch" \
-              --title "chore: package $tag" \
-              --body "Build and commit the distribution bundle for $tag.")"
+          if git diff --cached --quiet; then
+            echo "Release bundle is already current."
+            exit 0
           fi
-          gh pr merge "$pr_url" --auto --squash --delete-branch
-      - name: Publish the immutable release
-        if: "${{ !steps.release.outputs.release_created && startsWith(github.event.head_commit.message, 'chore: package v') }}"
-        env:
-          GH_TOKEN: ${{ secrets.BECKWITH_ROBOT_TOKEN }}
+
+          git commit -m "chore: build release bundle"
+          git push origin \
+            "HEAD:refs/heads/${{ fromJSON(steps.release.outputs.pr).headBranchName }}"
+      - name: Check out the released source
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ steps.release.outputs.sha }}
+          fetch-depth: 0
+          token: ${{ secrets.BECKWITH_ROBOT_TOKEN }}
+      - name: Update the floating action tags
+        if: ${{ steps.release.outputs.release_created == 'true' }}
         run: |
-          tag="v$(node --print "require('./package.json').version")"
-          major="$(cut -d. -f1 <<<"$tag")"
-          minor="$(cut -d. -f1-2 <<<"$tag")"
-
-          tag_sha="$(git rev-list -n 1 "$tag")"
-          if [[ -z "$tag_sha" ]] || ! git merge-base --is-ancestor "$tag_sha" HEAD; then
-            echo "Refusing to publish $tag from unrelated commit $tag_sha" >&2
-            exit 1
-          fi
-          if ! git ls-files --error-unmatch dist/index.cjs dist/index.cjs.map >/dev/null; then
-            echo "Refusing to publish $tag without a committed distribution bundle" >&2
-            exit 1
-          fi
-
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git tag --force --annotate "$tag" --message "Release $tag"
+
+          major='v${{ steps.release.outputs.major }}'
+          minor='v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}'
           git tag --force --annotate "$major" --message "Release $major"
           git tag --force --annotate "$minor" --message "Release $minor"
           git push --atomic origin \
-            "+refs/tags/$tag" \
             "+refs/tags/$major" \
             "+refs/tags/$minor"
-          gh release edit "$tag" --draft=false --latest

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,11 +1,9 @@
 {
-  "force-tag-creation": true,
   "packages": {
     ".": {
       "release-type": "node",
       "package-name": "linkinator-action",
-      "include-component-in-tag": false,
-      "draft": true
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
Fixes #285.

## What changed

- build and commit `dist/index.cjs` and its source map directly into the Release Please PR
- make the existing required `test` check rebuild release PR bundles and reject any generated diff
- let Release Please create the immutable version tag from the already-packaged merge commit
- retain the standard post-release updates for floating major and minor action tags
- remove the draft/tag-rewrite/secondary packaging-PR flow

## Root cause

The previous workflow allowed Release Please to create `v2.4.4` from a source-only commit, then attempted to add the bundle in a later protected-branch update. When that update was rejected, consumers could resolve an action ref whose `action.yml` pointed to the absent `dist/index.cjs`.

## Impact

A release PR cannot satisfy the required `test` check unless its committed bundle exactly matches the source. The immutable version tag is therefore created only from a merge commit that already contains the action entrypoint.

## Validation

- `npm test` — 37 tests passed
- `npm run lint`
- `npm run build` followed by a zero `dist/` diff
- `actionlint .github/workflows/ci.yaml .github/workflows/release-please.yml`
- `git diff --check`
