### PR TITLE
fix: package action bundle before release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: 24
           cache: npm
-      - name: Build the release bundle
+      - name: Build the bundle in the release pull request
         if: ${{ steps.release.outputs.prs_created == 'true' }}
         run: |
           npm ci


### PR DESCRIPTION
Follow-up to #287. GitHub's squash commit for that PR did not preserve the Conventional Commit colon, so Release Please could not parse it and skipped creating a release PR. This tiny workflow-label clarification provides an explicitly conventional commit; the squash merge will also use an explicit conventional subject.