### PR TITLE
fix(deps): update linkinator to 8.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",
-        "linkinator": "^8.0.0"
+        "linkinator": "^8.0.2"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.13",
@@ -1616,9 +1616,10 @@
       }
     },
     "node_modules/linkinator": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/linkinator/-/linkinator-8.0.0.tgz",
-      "integrity": "sha512-dMMTdJzRAJUCt41iKiimFjAytfAh7zY2Er9qNgncKWKKSCcMJ5DEnmy2+Sww1345JamUDbNYjg4MpMLqgV/9Sg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/linkinator/-/linkinator-8.0.2.tgz",
+      "integrity": "sha512-WZcGP5nW2GZ6uWskA2QZLu4KKZm0YYuocUzXh6nRuxHeObh5KqHi8rxA3rK5NAmJRHGC5uDAybgdeSstF1PLNg==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.0",
         "escape-html": "^1.0.3",
@@ -3015,9 +3016,9 @@
       "optional": true
     },
     "linkinator": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/linkinator/-/linkinator-8.0.0.tgz",
-      "integrity": "sha512-dMMTdJzRAJUCt41iKiimFjAytfAh7zY2Er9qNgncKWKKSCcMJ5DEnmy2+Sww1345JamUDbNYjg4MpMLqgV/9Sg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/linkinator/-/linkinator-8.0.2.tgz",
+      "integrity": "sha512-WZcGP5nW2GZ6uWskA2QZLu4KKZm0YYuocUzXh6nRuxHeObh5KqHi8rxA3rK5NAmJRHGC5uDAybgdeSstF1PLNg==",
       "requires": {
         "chalk": "^5.0.0",
         "escape-html": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/JustinBeckwith/linkinator-action#readme",
   "dependencies": {
     "@actions/core": "^3.0.0",
-    "linkinator": "^8.0.0"
+    "linkinator": "^8.0.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.13",


### PR DESCRIPTION
## Summary

- Update `linkinator` from `^8.0.0` to `^8.0.2`.
- Refresh the npm lockfile to resolve `linkinator@8.0.2`.

## Why

This picks up the fixes published in linkinator 8.0.1 and 8.0.2, including proxy handling, URL resolution and queue wake-ups, retry-count handling, and client-side fragment validation behavior.

I also investigated #286 while preparing this update. It remains reproducible in linkinator 8.0.2: manual redirect handling still prefers the original `response.url` over the `Location` header when formatting the redirect target. This PR therefore does not resolve #286.

## Validation

- `npm test` — 37 tests passed
- `npm run lint` — passed (existing Biome schema-version informational message)
- `npm run build` — passed
- `git diff --check` — passed
